### PR TITLE
Twilio and Twilio::REST are modules, not classes - #1

### DIFF
--- a/lib/sms_spec/drivers/twilio-ruby.rb
+++ b/lib/sms_spec/drivers/twilio-ruby.rb
@@ -1,5 +1,5 @@
-class Twilio
-  class REST
+module Twilio
+  module REST
     class Client
 
       def initialize(account_sid, auth_token)


### PR DESCRIPTION
It looks like these have both been modules for quite some time (https://github.com/twilio/twilio-ruby/blame/master/lib/twilio-ruby/rest/client.rb), so this change should be sufficient.
