### PR TITLE
Allow sms-spec to be used with RSpec 3

### DIFF
--- a/sms-spec.gemspec
+++ b/sms-spec.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'rspec', "~> 2.11"
+  s.add_dependency 'rspec', ">= 2.11"
   s.add_development_dependency "rake"
   s.add_development_dependency "twilio-ruby", "~> 3.0"
   s.add_development_dependency "lookout-clickatell", "~> 0.8"


### PR DESCRIPTION
It appears bcd3b8e1ac5a70e2b65e148323f2a54bf35e5156 added support for RSpec 3, however the dependency in the gemspec still locks RSpec to a version on the 2.X series.
