### PR TITLE
Don't force the account_sid and auth_token to be passed when initializing a client incase they were set in the block configuration

### DIFF
--- a/lib/sms_spec/drivers/twilio-ruby.rb
+++ b/lib/sms_spec/drivers/twilio-ruby.rb
@@ -1,37 +1,34 @@
+require 'twilio-ruby'
+
 module Twilio
   module REST
+
     class Client
-
-      def initialize(account_sid, auth_token)
-        $account_sid = account_sid
-      end
-
-      class Messages
-        include SmsSpec::Helpers
-
-        def create(opts={})
-          to = opts[:to]
-          body = opts[:body]
-          from = opts[:from]
-          add_message SmsSpec::Message.new(:number => to, :from => from, :body => body)
-        end
-      end
-
-      class Account
-        def sms
-          Sms.new
-        end
-
-        def messages
-          Messages.new
-        end
-      end
-
       def account
-        account = Account.new
-        account.class.send(:define_method, :sid, lambda { $account_sid })
-        account
+        Account.new(nil, self, sid: @account_sid)
       end
     end
+
+    class Messages
+      include SmsSpec::Helpers
+
+      def create(opts={})
+        to = opts[:to]
+        body = opts[:body]
+        from = opts[:from]
+        add_message SmsSpec::Message.new(:number => to, :from => from, :body => body)
+      end
+    end
+
+    class Account
+      def sms
+        Sms.new
+      end
+
+      def messages
+        Messages.new
+      end
+    end
+
   end
 end

--- a/spec/drivers/twilio_spec.rb
+++ b/spec/drivers/twilio_spec.rb
@@ -59,5 +59,18 @@ describe SmsSpec do
       expect(current_text_message.from).to eq('+14159341234')
     end
 
+    it 'allows the account_sid and auth_token to be set via the block configuration' do
+      account_sid = 'ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+
+      Twilio.configure do |config|
+        config.account_sid = account_sid
+        config.auth_token = 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy'
+      end
+
+      @client = Twilio::REST::Client.new
+
+      expect(@client.account.sid).to be(account_sid)
+    end
+
   end
 end


### PR DESCRIPTION
twilio-ruby v3.13.1 added the block configure syntax:
https://github.com/twilio/twilio-ruby/commit/5e5485fbf76c5fcc4b8bf1d04c1e288a9104b9e9

I moved `Account` and `Message` out of the `Twilio::REST::Client` namespace to match the official gem's structure and take advantage of most of the native functionality.
