### PR TITLE
Adding BaseClient class to mimic latest twilio-ruby library.

### DIFF
--- a/lib/sms_spec/drivers/twilio-ruby.rb
+++ b/lib/sms_spec/drivers/twilio-ruby.rb
@@ -20,7 +20,11 @@ module Twilio
   private_class_method :configuration
 
   module REST
-    class Client
+    class BaseClient
+
+    end
+
+    class Client < BaseClient
 
       def initialize(*args)
         # mimic the primary class's #initialize.


### PR DESCRIPTION
The latest twilio-ruby library has a new class BaseClient from which Client inherits.