### PR TITLE
Adds examples to readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,7 +15,7 @@ Add the sms-spec gem to `Gemfile`:
 
 ```ruby
 group :test do
-  gem 'sms-spec'
+  gem "sms-spec"
 end
 ```
 
@@ -23,30 +23,30 @@ end
 Configure a driver and include helper and matcher methods in the `spec_helper.rb`:
 
 ```ruby
-require 'sms_spec'
+require "sms_spec"
 
 Spec::Runner.configure do |config|
   config.include(SmsSpec::Helpers)
   config.include(SmsSpec::Matchers)
 end
 
-SmsSpec.driver = :'twilio-ruby' #this can be any available sms-spec driver
+SmsSpec.driver = :"twilio-ruby" #this can be any available sms-spec driver
 ```
 
 ### Usage
 
 ```ruby
-describe 'alarm notifications' do
+describe "alarm notifications" do
   subject(:job) { AlarmNotificationJob.new }
 
-  context 'via sms' do
+  context "via sms" do
     let!(:subscription) { FactoryGirl.create :alarm_subscription_sms }
 
     it "delivers an alarm notification" do
       job.perform
 
       open_last_text_message_for(subscription.recipient)
-      expect(current_text_message.body).to eq('Yo')
+      expect(current_text_message.body).to eq("Yo")
     end
   end
 end
@@ -56,8 +56,8 @@ end
 Add the following to `env.rb`:
 
 ```ruby
-require 'sms_spec'
-require 'sms_spec/cucumber'
+require "sms_spec"
+require "sms_spec/cucumber"
 ```
 
 This loads the `sms_spec` RSpec helpers into your cucumber wold. Then,

--- a/README.markdown
+++ b/README.markdown
@@ -30,7 +30,26 @@ Spec::Runner.configure do |config|
   config.include(SmsSpec::Matchers)
 end
 
-SmsSpec.driver = :twilio-ruby #this can be any available sms-spec driver
+SmsSpec.driver = :'twilio-ruby' #this can be any available sms-spec driver
+```
+
+### Usage
+
+```ruby
+describe 'alarm notifications' do
+  subject(:job) { AlarmNotificationJob.new }
+
+  context 'via sms' do
+    let!(:subscription) { FactoryGirl.create :alarm_subscription_sms }
+
+    it "delivers an alarm notification" do
+      job.perform
+
+      open_last_text_message_for(subscription.recipient)
+      expect(current_text_message.body).to eq('Yo')
+    end
+  end
+end
 ```
 
 ## Cucumber
@@ -41,9 +60,28 @@ require 'sms_spec'
 require 'sms_spec/cucumber'
 ```
 
-This loads the sms_spec RSpec helpers into your cucumber wold. Then,
-run the following to generate the text_messsage_steps.rb file:
+This loads the `sms_spec` RSpec helpers into your cucumber wold. Then,
+run the following to generate the `text_messsage_steps.rb` file:
 
 ```ruby
 rails generate sms_spec:steps
+```
+
+### Usage
+
+```ruby
+Feature: Registering via SMS
+
+  In order to use our application
+  As a user
+  I want to be able to register with any mobile phone
+
+  Scenario: A user submits their phone number for registration
+    Given I am on the homepage
+    And I fill in "What is your phone number?" with "6165552345"
+    When I press "Register"
+
+    Then I should see "Thank You"
+    And "6165552345" opens the text message
+    And I should see "Thank you for registering. To confirm your subscript reply YES." in the text message body
 ```


### PR DESCRIPTION
I had to do additional searching to find a blog post to explain how to use this gem, so I put some quick examples in the readme to make it easier for people to pick up how to use sms-spec.